### PR TITLE
ITEM_PIPELINES update to dict

### DIFF
--- a/Sina_spider1/Sina_spider1/settings.py
+++ b/Sina_spider1/Sina_spider1/settings.py
@@ -9,7 +9,9 @@ DOWNLOADER_MIDDLEWARES = {
     "Sina_spider1.middleware.CookiesMiddleware": 402,
 }
 
-ITEM_PIPELINES = ["Sina_spider1.pipelines.MongoDBPipleline"]
+ITEM_PIPELINES = {
+    'Sina_spider1.pipelines.MongoDBPipleline': 300,
+}
 
 DOWNLOAD_DELAY = 2  # 间隔时间
 # CONCURRENT_ITEMS = 1000


### PR DESCRIPTION
ITEM_PIPELINES as a list is deprecated in scrapy v1.1.0, change it to a dict.